### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   linkcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: lycheeverse/lychee-action@v2.0.2


### PR DESCRIPTION
Potential fix for [https://github.com/emmanuelgjr/GenAI-Security-Crosswalk/security/code-scanning/3](https://github.com/emmanuelgjr/GenAI-Security-Crosswalk/security/code-scanning/3)

In general, the problem is fixed by explicitly declaring a `permissions` block either at the workflow root (to apply to all jobs) or within the specific job, granting only those scopes actually required. For a read-only link check that only needs to read repository contents, the minimal safe setting is `permissions: contents: read`.

The best fix here is to add a `permissions` block under the `linkcheck` job in `.github/workflows/link-check.yml`, at the same indentation level as `runs-on`. This avoids impacting other workflows and clearly scopes the job’s token. We will set `contents: read`, which is sufficient for checking out the code and scanning Markdown files. No changes to steps or behavior are needed.

Concretely:
- In `.github/workflows/link-check.yml`, locate the `jobs: linkcheck:` block.
- Insert a new `permissions:` mapping below `runs-on: ubuntu-latest`.
- Under `permissions:`, add `contents: read` properly indented.

No additional imports, methods, or definitions are required because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
