### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,6 +2,8 @@ name: Markdown lint
 on: [push, pull_request]
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/emmanuelgjr/GenAI-Security-Crosswalk/security/code-scanning/2](https://github.com/emmanuelgjr/GenAI-Security-Crosswalk/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job, granting only the minimal scopes required. For this markdown lint job, it only needs to read repository contents, so `contents: read` is sufficient. Defining this at the job level addresses the CodeQL finding and documents the intended permissions clearly.

The single best fix here is to add a `permissions` section under the `lint` job (line 5) in `.github/workflows/markdown-lint.yml`, just above `runs-on`. This will scope the job’s `GITHUB_TOKEN` to read-only repository contents and will not change the workflow’s functional behavior because the job only checks out the code and runs a linter. No imports or additional methods are needed; it is purely a YAML configuration change. The block to add is:

```yaml
    permissions:
      contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
