### PR TITLE
chore: housekeeping fixes + ATLAS URL linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `scripts/validate.js`: MITRE ATLAS URL hash-routing check — flags bare `atlas.mitre.org/techniques/…` links (which 404) and requires the SPA `/#/techniques/…` form
+
+### Fixed
+- Stale incident counts corrected to **114** in `README.md` and `data/README.md` (were "50", out of sync with `data/incidents.json`)
+- Corrected stale total-mappings figure in `README.md` (3,210 → **3,235**, matching `data/entries`)
+- EO 14110 framing in NIST AI RMF files (LLM, Agentic, DSGAI): the AI RMF is voluntary; EO 14110 was revoked January 2025 — removed inaccurate "required" language and aligned reference/audience notes
+- `i18n/README.md` translation status table now reflects actual state (Spanish, German, Japanese machine-assisted drafts synced 2026-03-28; Portuguese planned)
+- Added missing `## See also` back-reference (DSGAI × AIUC-1 → DSGAI × ISO 42001), resolving the last validator warning
+
 Next: npm publish to npmjs.com, custom domain (crosswalk.owasp.org), vendor integration packs, NeMo Guardrails configs.
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <strong>The most comprehensive mapping of AI security risks to compliance frameworks.</strong><br>
-  25 frameworks &middot; 1,514 controls &middot; 41 entries &middot; 3,210 mappings &middot; 114 incidents &middot; ML classifier pipeline
+  25 frameworks &middot; 1,514 controls &middot; 41 entries &middot; 3,235 mappings &middot; 114 incidents &middot; ML classifier pipeline
 </p>
 
 <p align="center">
@@ -130,7 +130,7 @@ Every file answers one question: **which controls from framework X address vulne
 | **70+** open-source tools | Catalogued and organised by function |
 | **25** eval profiles | Runnable Garak (13) + PyRIT (6) + LAAF (6) tests mapped to OWASP entries |
 | **23** compliance reports | Per-framework gap assessments auto-generated from data layer (MD, CSV, JSON, OSCAL, GRC) |
-| **50** documented incidents | Real-world + research incidents with MAESTRO layer attribution (MD, CSV, JSON, STIX 2.1) |
+| **114** documented incidents | Real-world + research incidents with MAESTRO layer attribution (MD, CSV, JSON, STIX 2.1) |
 | **LAAF v2.0** | First agentic LPCI red-teaming framework — fully integrated with 6-stage × OWASP crosswalk |
 | **25** framework registries | First-class control inventories (1,514 controls) with backlink index |
 | **Classifier pipeline** | BGE bi-encoder + cross-encoder reranker — auto-maps new frameworks to OWASP entries |

--- a/agentic-top10/Agentic_NISTAIRMF.md
+++ b/agentic-top10/Agentic_NISTAIRMF.md
@@ -31,7 +31,7 @@ technical controls.
 
 ## Why NIST AI RMF for agentic AI security
 
-The NIST AI Risk Management Framework (AI RMF 1.0) is the primary US federal AI risk management framework, required for US federal agencies under Executive Order 14110 and widely adopted globally by enterprises and critical infrastructure operators. Its four-function lifecycle structure (GOVERN, MAP, MEASURE, MANAGE) maps naturally to agentic risk because agentic risks compound across the lifecycle -- a governance gap enables a mapping gap that manifests as an undetected cascade. This mapping traces each OWASP Agentic Top 10 risk to specific AI RMF subcategories for teams deploying autonomous AI agents.
+The NIST AI Risk Management Framework (AI RMF 1.0) is the primary US federal AI risk management framework, which US federal agencies were directed to align with under Executive Order 14110 (revoked January 2025) and which is widely adopted globally by enterprises and critical infrastructure operators. The AI RMF itself remains a voluntary framework. Its four-function lifecycle structure (GOVERN, MAP, MEASURE, MANAGE) maps naturally to agentic risk because agentic risks compound across the lifecycle -- a governance gap enables a mapping gap that manifests as an undetected cascade. This mapping traces each OWASP Agentic Top 10 risk to specific AI RMF subcategories for teams deploying autonomous AI agents.
 
 ---
 
@@ -67,7 +67,7 @@ The NIST AI Risk Management Framework (AI RMF 1.0) is the primary US federal AI 
 
 - **CISO / governance** — full file, AI RMF alignment for agentic AI programme
 - **Risk manager** — MAP and MEASURE subcategories, risk register entries
-- **Federal agency teams** — EO 14110 alignment for agentic deployments
+- **Federal agency teams** — federal AI governance alignment for agentic deployments (AI RMF; EO 14110 revoked January 2025)
 - **AI/ML engineer** — MEASURE subcategories, testing and monitoring entries
 - **Security engineer** — MANAGE subcategories, incident response entries
 - **OT engineer** — ASI02, ASI08 with ISA 62443 crosswalk for OT context
@@ -792,7 +792,7 @@ covered in the evaluation programme (MS-2.5) and incident response
 - [NIST AI RMF Playbook](https://airc.nist.gov/Docs/2)
 - [OWASP Agentic Top 10 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
 - [OWASP AIVSS](https://aivss.owasp.org)
-- [Executive Order 14110](https://www.whitehouse.gov/briefing-room/presidential-actions/2023/10/30/executive-order-on-the-safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence/)
+- [Executive Order 14110 on Safe, Secure, and Trustworthy AI (revoked January 2025)](https://www.whitehouse.gov/briefing-room/presidential-actions/2023/10/30/executive-order-on-the-safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence/)
 
 ---
 

--- a/data/README.md
+++ b/data/README.md
@@ -12,7 +12,7 @@ dashboard integration, and downstream tooling without scraping Markdown.
 |---|---|
 | `schema.json` | JSON Schema (Draft 7) defining the structure of all entry files |
 | `incidents-schema.json` | JSON Schema for incident entries |
-| `incidents.json` | 50 real-world + research AI security incidents with MAESTRO layer attribution |
+| `incidents.json` | 114 real-world + research AI security incidents with MAESTRO layer attribution |
 | `tools-supplement.json` | Supplemental tool entries merged into entries at generation time |
 | `entries/` | 41 machine-readable JSON files — one per OWASP entry (LLM01–LLM10, ASI01–ASI10, DSGAI01–DSGAI21) |
 | `framework-schema.json` | JSON Schema for framework registry entries |

--- a/dsgai-2026/DSGAI_AIUC1.md
+++ b/dsgai-2026/DSGAI_AIUC1.md
@@ -546,6 +546,7 @@ Adversaries poison RAG knowledge bases, manipulate training data, or exploit mod
 
 - [LLM Top 10 × AIUC-1](../llm-top10/LLM_AIUC1.md)
 - [Agentic Top 10 × AIUC-1](../agentic-top10/Agentic_AIUC1.md)
+- [DSGAI 2026 × ISO 42001](DSGAI_ISO42001.md)
 
 ---
 

--- a/dsgai-2026/DSGAI_NISTAIRMF.md
+++ b/dsgai-2026/DSGAI_NISTAIRMF.md
@@ -21,8 +21,9 @@ to AI risk that maps naturally to the DSGAI 2026 data security taxonomy,
 which follows data as it moves through a GenAI system from ingestion
 through inference to output and operational exhaust.
 
-This mapping is particularly valuable for US federal agencies (required
-to align with the AI RMF under Executive Order 14110), critical
+This mapping is particularly valuable for US federal agencies (directed
+to align with the AI RMF under Executive Order 14110, revoked January
+2025; the AI RMF itself remains voluntary), critical
 infrastructure operators, and enterprises running AI RMF-aligned AI
 governance programmes who need to operationalise the DSGAI risks within
 their existing framework.
@@ -76,7 +77,7 @@ their existing framework.
 - **Compliance officer** — GV subcategories, regulatory intersection notes
 - **ML / AI engineer** — MEASURE subcategories, testing and data quality entries
 - **Security engineer** — MANAGE subcategories, incident response entries
-- **Federal agency teams** — full file, EO 14110 alignment
+- **Federal agency teams** — full file, federal AI governance alignment (AI RMF; EO 14110 revoked January 2025)
 - **OT engineer** — DSGAI04, DSGAI12, DSGAI17 with ISA 62443 and NIST SP 800-82 crosswalks
 
 ---

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -13,8 +13,10 @@ OWASP GenAI security research to the global community.
 
 | Language | Code | Status | Maintainer |
 |---|---|---|---|
-| Spanish | `es/` | ?? Planned — contributions welcome | Open |
-| Portuguese | `pt/` | ?? Planned — contributions welcome | Open |
+| Spanish | `es/` | Machine-assisted draft (synced 2026-03-28) — needs native-speaker review & re-sync | Open |
+| German | `de/` | Machine-assisted draft (synced 2026-03-28) — needs native-speaker review & re-sync | Open |
+| Japanese | `ja/` | Machine-assisted draft (synced 2026-03-28) — needs native-speaker review & re-sync | Open |
+| Portuguese | `pt/` | Planned — contributions welcome | Open |
 
 To add your language, see **Contributing a translation** below.
 

--- a/llm-top10/LLM_NISTAIRMF.md
+++ b/llm-top10/LLM_NISTAIRMF.md
@@ -18,8 +18,9 @@ in the United States and is widely adopted globally by enterprises,
 government agencies, and critical infrastructure operators. It organises
 AI risk management across four core functions — GOVERN, MAP, MEASURE,
 MANAGE — each with subcategories that map directly to LLM security controls.
-US federal agencies are required to align with the AI RMF under Executive
-Order 14110. It is the foundational framework for enterprise AI governance
+US federal agencies were directed to align with the AI RMF under Executive
+Order 14110 (revoked January 2025); the AI RMF itself remains a voluntary
+framework. It is the foundational framework for enterprise AI governance
 programmes and pairs directly with NIST CSF 2.0 for organisations already
 using the cybersecurity framework.
 
@@ -27,7 +28,7 @@ using the cybersecurity framework.
 
 ## Why NIST AI RMF for LLM security
 
-The NIST AI Risk Management Framework (AI RMF 1.0) is the primary US federal AI risk management framework, widely adopted by enterprises, government agencies, and critical infrastructure operators globally, and required for US federal agencies under Executive Order 14110. This mapping traces each OWASP LLM risk to specific AI RMF subcategories across GOVERN, MAP, MEASURE, and MANAGE -- enabling organisations to operationalise LLM security within their existing AI governance programme.
+The NIST AI Risk Management Framework (AI RMF 1.0) is the primary US federal AI risk management framework, widely adopted by enterprises, government agencies, and critical infrastructure operators globally. US federal agencies were directed to align with it under Executive Order 14110 (revoked January 2025); the framework itself remains voluntary. This mapping traces each OWASP LLM risk to specific AI RMF subcategories across GOVERN, MAP, MEASURE, and MANAGE -- enabling organisations to operationalise LLM security within their existing AI governance programme.
 
 ---
 

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -200,6 +200,34 @@ function checkCrossRefFormat(filePath, content) {
 }
 
 /**
+ * 6b. MITRE ATLAS URL hash-routing
+ *     atlas.mitre.org is a single-page app using hash routing, so deep links
+ *     must use the `/#/techniques/AML.TXXXX` form. The bare `/techniques/...`
+ *     form (no `/#`) 404s. Same for /tactics/ and /mitigations/.
+ */
+function checkAtlasUrls(filePath, content) {
+  const rel = relPath(filePath);
+  // Match any atlas.mitre.org URL and capture the path that follows the host
+  const urlRe = /https?:\/\/atlas\.mitre\.org(\/[^)\s"'<>]*)/g;
+  let bad = 0;
+
+  for (const match of content.matchAll(urlRe)) {
+    const urlPath = match[1];
+    // Routed sections must be reached via the SPA hash (`/#/...`)
+    if (/^\/(techniques|tactics|mitigations|matrices|studies)\//.test(urlPath)) {
+      fail(
+        rel,
+        `MITRE ATLAS URL must use hash routing (/#${urlPath}); bare ${urlPath} 404s`
+      );
+      bad++;
+    }
+  }
+
+  if (bad === 0) pass(rel, 'MITRE ATLAS URLs use hash routing');
+  return bad === 0;
+}
+
+/**
  * 7. Bidirectional cross-references
  *    If file A mentions "See also: Agentic_FOO.md", then Agentic_FOO.md
  *    should mention a link back to the source file or its parent source list.
@@ -402,6 +430,7 @@ function run() {
     checkChangelog(fp, content);
     checkHeader(fp, content);
     checkCrossRefFormat(fp, content);
+    checkAtlasUrls(fp, content);
   }
 
   // Bidirectional cross-reference check (expensive — skip in quick mode)


### PR DESCRIPTION
## Summary

Documentation/accuracy cleanup plus one new validator guard. All changes are low-risk and verified — validator reports **0 errors, 0 warnings, 346 checks passed**.

### Fixed
- **Stale incident counts** — `README.md` and `data/README.md` said "50"; `data/incidents.json` has **114**. Corrected both.
- **Stale total-mappings figure** — `README.md` header said `3,210 mappings`; actual count across `data/entries` is **3,235**. Corrected.
- **EO 14110 framing** — NIST AI RMF files (LLM, Agentic, DSGAI) described the AI RMF as "required for US federal agencies under Executive Order 14110." EO 14110 was **revoked January 2025** and the AI RMF is voluntary. Reworded intros, the Agentic reference link, and federal-agency audience tags.
- **i18n status table** — `i18n/README.md` listed Spanish/Portuguese as "Planned" and omitted German/Japanese. Updated to reflect reality: `es`/`de`/`ja` are machine-assisted drafts (synced 2026-03-28), `pt` is planned/empty.
- **One-way link warning** — added `DSGAI × AIUC-1 → DSGAI × ISO 42001` back-reference, clearing the last validator warning.

### Added
- **MITRE ATLAS URL linter** in `scripts/validate.js` — `atlas.mitre.org` is a hash-routed SPA, so deep links must use `/#/techniques/AML.TXXXX`; the bare `/techniques/…` form 404s. New per-file check flags the bad form (also `/tactics/`, `/mitigations/`, `/matrices/`, `/studies/`). Verified: passes on current content; flags all 26 injected bad URLs in a negative test.

## Out of scope
Coverage-gap mapping files (`Agentic_STRIDE`, `DSGAI_STRIDE`, `DSGAI_AITG`) are intentionally **not** in this PR — ~700–1,000+ line authoritative mappings that warrant their own focused review.

## Test plan
- [x] `node scripts/validate.js` → 0 errors, 0 warnings, 346 passed
- [x] ATLAS linter negative test (26/26 bad URLs caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)