### PR TITLE
fix(dsgai): repair malformed "## Why" sections in 10 files + add guard

### DIFF
--- a/dsgai-2026/DSGAI_ASVS.md
+++ b/dsgai-2026/DSGAI_ASVS.md
@@ -22,7 +22,11 @@ enables security engineers and penetration testers to translate DSGAI threats in
 verifiable ASVS requirements for inclusion in security test plans.
 
 ---
-## Why # DSGAI 2026 × OWASP ASVS 4.0.3 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × OWASP ASVS 4.0.3 controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × OWASP ASVS 4.0.3 compliance and governance programmes.---
+## Why OWASP ASVS 4.0.3 for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific OWASP ASVS 4.0.3 controls, enabling data security teams to address GenAI-specific data risks within their existing OWASP ASVS 4.0.3 compliance and governance programmes.
+
+---
 
 ## ASVS structure
 

--- a/dsgai-2026/DSGAI_CISControls.md
+++ b/dsgai-2026/DSGAI_CISControls.md
@@ -23,7 +23,11 @@ and service provider management (CIS 15) — covering the full GenAI data lifecy
 from training through inference.
 
 ---
-## Why # DSGAI 2026 × CIS Controls v8.1 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × CIS Controls v8.1 controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × CIS Controls v8.1 compliance and governance programmes.---
+## Why CIS Controls v8.1 for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific CIS Controls v8.1 controls, enabling data security teams to address GenAI-specific data risks within their existing CIS Controls v8.1 compliance and governance programmes.
+
+---
 
 ## CIS Controls structure
 

--- a/dsgai-2026/DSGAI_CWE_CVE.md
+++ b/dsgai-2026/DSGAI_CWE_CVE.md
@@ -21,7 +21,11 @@ using the same taxonomy applied to the rest of the application stack. CVE entrie
 provide confirmed real-world exploitation evidence for DSGAI risk areas.
 
 ---
-## Why # DSGAI 2026 × CWE / CVE for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × CWE / CVE controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × CWE / CVE compliance and governance programmes.---
+## Why CWE / CVE for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific CWE / CVE controls, enabling data security teams to address GenAI-specific data risks within their existing CWE / CVE compliance and governance programmes.
+
+---
 
 ## CWE pillar families most relevant to DSGAI
 

--- a/dsgai-2026/DSGAI_EUAIAct.md
+++ b/dsgai-2026/DSGAI_EUAIAct.md
@@ -26,7 +26,11 @@ integrity and pipeline risks. The GDPR runs in parallel for any DSGAI
 entry involving personal data — both apply simultaneously.
 
 ---
-## Why # DSGAI 2026 × EU AI Act for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × EU AI Act controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × EU AI Act compliance and governance programmes.---
+## Why EU AI Act for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific EU AI Act controls, enabling data security teams to address GenAI-specific data risks within their existing EU AI Act compliance and governance programmes.
+
+---
 
 ## Compliance timeline reminder
 

--- a/dsgai-2026/DSGAI_ISO27001.md
+++ b/dsgai-2026/DSGAI_ISO27001.md
@@ -28,7 +28,11 @@ certification does not substitute for those obligations but provides
 foundational evidence of security controls.
 
 ---
-## Why # DSGAI 2026 × ISO/IEC 27001:2022 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × ISO/IEC 27001:2022 controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × ISO/IEC 27001:2022 compliance and governance programmes.---
+## Why ISO/IEC 27001:2022 for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific ISO/IEC 27001:2022 controls, enabling data security teams to address GenAI-specific data risks within their existing ISO/IEC 27001:2022 compliance and governance programmes.
+
+---
 
 ## ISO 27001:2022 Annex A control domains
 

--- a/dsgai-2026/DSGAI_MAESTRO.md
+++ b/dsgai-2026/DSGAI_MAESTRO.md
@@ -18,7 +18,11 @@ the Cloud Security Alliance's threat modeling framework for agentic AI.
 Co-Chair of AI Safety Working Groups, Cloud Security Alliance.
 
 ---
-## Why # DSGAI 2026 × MAESTRO for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × MAESTRO controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × MAESTRO compliance and governance programmes.---
+## Why MAESTRO for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific MAESTRO controls, enabling data security teams to address GenAI-specific data risks within their existing MAESTRO compliance and governance programmes.
+
+---
 
 ## MAESTRO and GenAI data security
 

--- a/dsgai-2026/DSGAI_NISTAIRMF.md
+++ b/dsgai-2026/DSGAI_NISTAIRMF.md
@@ -29,7 +29,11 @@ governance programmes who need to operationalise the DSGAI risks within
 their existing framework.
 
 ---
-## Why # DSGAI 2026 × NIST AI RMF for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × NIST AI RMF controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × NIST AI RMF compliance and governance programmes.---
+## Why NIST AI RMF for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific NIST AI RMF controls, enabling data security teams to address GenAI-specific data risks within their existing NIST AI RMF compliance and governance programmes.
+
+---
 
 ## AI RMF core functions — GenAI data security lens
 

--- a/dsgai-2026/DSGAI_NISTCSF2.md
+++ b/dsgai-2026/DSGAI_NISTCSF2.md
@@ -21,7 +21,11 @@ data security — data governance policy, supply chain oversight,
 and acceptable use requirements are GOVERN responsibilities.
 
 ---
-## Why # DSGAI 2026 × NIST CSF 2.0 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × NIST CSF 2.0 controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × NIST CSF 2.0 compliance and governance programmes.---
+## Why NIST CSF 2.0 for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific NIST CSF 2.0 controls, enabling data security teams to address GenAI-specific data risks within their existing NIST CSF 2.0 compliance and governance programmes.
+
+---
 
 ## Quick-reference summary
 

--- a/dsgai-2026/DSGAI_PCIDSS.md
+++ b/dsgai-2026/DSGAI_PCIDSS.md
@@ -28,7 +28,11 @@ CHD is unavoidable, apply PCI scope controls to every component
 that touches it.
 
 ---
-## Why # DSGAI 2026 × PCI DSS v4.0 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × PCI DSS v4.0 controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × PCI DSS v4.0 compliance and governance programmes.---
+## Why PCI DSS v4.0 for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific PCI DSS v4.0 controls, enabling data security teams to address GenAI-specific data risks within their existing PCI DSS v4.0 compliance and governance programmes.
+
+---
 
 ## Quick-reference summary
 

--- a/dsgai-2026/DSGAI_SOC2.md
+++ b/dsgai-2026/DSGAI_SOC2.md
@@ -29,7 +29,11 @@ are implicated throughout the DSGAI taxonomy, not only in the
 obviously data-focused entries.
 
 ---
-## Why # DSGAI 2026 × SOC 2 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × SOC 2 controls, enabling data security teams to address GenAI-specific data risks within their existing # DSGAI 2026 × SOC 2 compliance and governance programmes.---
+## Why SOC 2 for GenAI data security
+
+This mapping traces each OWASP DSGAI 2026 data security risk to specific SOC 2 controls, enabling data security teams to address GenAI-specific data risks within their existing SOC 2 compliance and governance programmes.
+
+---
 
 ## Quick-reference summary
 

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -110,6 +110,13 @@ function checkSections(filePath, content) {
       ok = false;
     }
   }
+  // Malformed "## Why" heading: a templating-substitution bug pasted the H1
+  // title into the heading (e.g. "## Why # DSGAI 2026 × …"). The heading must
+  // not contain a "#" after "Why".
+  if (/^##\s+why\s+#/im.test(content)) {
+    fail(rel, 'Malformed "## Why" heading (contains a "#" — templating-substitution bug)');
+    ok = false;
+  }
   if (ok) pass(rel, 'All required sections present');
   return ok;
 }


### PR DESCRIPTION
## Summary

A templating-substitution bug had corrupted the `## Why` section in **10 DSGAI files**: the H1 title was pasted into the heading and the body + `---` separator were concatenated onto a single line, e.g.

```
## Why # DSGAI 2026 × OWASP ASVS 4.0.3 for GenAI data securityThis mapping traces each OWASP DSGAI 2026 data security risk to specific # DSGAI 2026 × OWASP ASVS 4.0.3 controls…compliance and governance programmes.---
```

The validator's `## Why` check (`/^##\s+why\s+/im`) matched it, so it slipped through.

## What changed
- Rebuilt clean sections in all 10: `DSGAI_ASVS`, `DSGAI_CISControls`, `DSGAI_CWE_CVE`, `DSGAI_EUAIAct`, `DSGAI_ISO27001`, `DSGAI_MAESTRO`, `DSGAI_NISTAIRMF`, `DSGAI_NISTCSF2`, `DSGAI_PCIDSS`, `DSGAI_SOC2`:

  ```
  ## Why <framework> for GenAI data security

  This mapping traces each OWASP DSGAI 2026 data security risk to specific
  <framework> controls, enabling data security teams to address GenAI-specific
  data risks within their existing <framework> compliance and governance programmes.
  ```
- **Recurrence guard:** `scripts/validate.js` now fails any `## Why #` heading.

## Verification
- [x] No `## Why #` remains in `llm-top10/`, `agentic-top10/`, `dsgai-2026/`
- [x] `node scripts/validate.js` → **0 errors, 0 warnings, 374 passed**
- [x] markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)