### PR TITLE
chore(readme): refresh stale stats in README, banner, og-image, citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ url: "https://emmanuelgjr.github.io/GenAI-Security-Crosswalk/"
 abstract: >-
   The most comprehensive publicly available mapping of AI security risks
   to industry compliance frameworks. Maps 41 OWASP GenAI vulnerability
-  entries (LLM Top 10, Agentic Top 10, DSGAI 2026) to 1,514 controls
+  entries (LLM Top 10, Agentic Top 10, DSGAI 2026) to 1,507 controls
   across 25 frameworks including EU AI Act, NIST AI RMF, ISO 42001,
   SOC 2, FedRAMP, DORA, PCI DSS, and MITRE ATLAS. Includes 114
   documented AI security incidents, a semantic classifier pipeline

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
   <a href="https://genai.owasp.org"><img src="https://img.shields.io/badge/OWASP-GenAI%20Data%20Security-blue" alt="OWASP"></a>
   <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-3.1.0-green" alt="Version"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/frameworks-25-orange" alt="Frameworks"></a>
-  <a href="README.md"><img src="https://img.shields.io/badge/controls-1,514-blueviolet" alt="Controls"></a>
+  <a href="README.md"><img src="https://img.shields.io/badge/controls-1,507-blueviolet" alt="Controls"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/mapping%20files-70-brightgreen" alt="Mapping Files"></a>
   <a href="https://www.npmjs.com/package/genai-security-crosswalk"><img src="https://img.shields.io/npm/v/genai-security-crosswalk?color=red&label=npm" alt="npm"></a>
 </p>
 
 <p align="center">
   <strong>The most comprehensive mapping of AI security risks to compliance frameworks.</strong><br>
-  25 frameworks &middot; 1,514 controls &middot; 41 entries &middot; 3,351 mappings &middot; 125 incidents &middot; ML classifier pipeline
+  25 frameworks &middot; 1,507 controls &middot; 41 entries &middot; 3,351 mappings &middot; 125 incidents &middot; ML classifier pipeline
 </p>
 
 <p align="center">
@@ -104,7 +104,7 @@ The `classifier/` directory contains a research-grade retrieval pipeline for aut
 ```bash
 cd classifier/
 pip install -r requirements.txt
-python -m classifier.index_builder            # build FAISS index (1,514 controls, ~7s)
+python -m classifier.index_builder            # build FAISS index (1,507 controls, ~7s)
 python -m classifier.classify --source LLM01 --top-k 10          # bi-encoder retrieval
 python -m classifier.classify --source LLM01 --top-k 10 --rerank # + cross-encoder reranker
 python -m classifier.eval_harness --rerank    # full eval with bootstrap CIs
@@ -132,7 +132,7 @@ Every file answers one question: **which controls from framework X address vulne
 | **23** compliance reports | Per-framework gap assessments auto-generated from data layer (MD, CSV, JSON, OSCAL, GRC) |
 | **125** documented incidents | Synced from the [genai_incidents](https://github.com/emmanuelgjr/genai_incidents) source of truth (curated tier); MAESTRO attribution, MD/CSV/JSON/STIX 2.1 |
 | **LAAF v2.0** | First agentic LPCI red-teaming framework — fully integrated with 6-stage × OWASP crosswalk |
-| **25** framework registries | First-class control inventories (1,514 controls) with backlink index |
+| **25** framework registries | First-class control inventories (1,507 controls) with backlink index |
 | **Classifier pipeline** | BGE bi-encoder + cross-encoder reranker — auto-maps new frameworks to OWASP entries |
 | **Submit-a-Standard** | Paste framework JSON → classifier proposes mappings → PR opened for review |
 
@@ -380,7 +380,7 @@ GenAI-Security-Crosswalk/
 │   └── TEMPLATE.md                  ← Canonical template for new mapping files
 │
 ├── data/
-│   ├── frameworks/                  ← 25 framework registries (1,514 controls)
+│   ├── frameworks/                  ← 25 framework registries (1,507 controls)
 │   ├── entries/                     ← 41 machine-readable entry JSON files
 │   ├── framework-schema.json        ← JSON Schema for framework registries
 │   ├── schema.json                  ← JSON Schema (Draft 7) for entry files
@@ -404,7 +404,7 @@ GenAI-Security-Crosswalk/
 ├── classifier/                      ← ML pipeline for automated mapping
 │   ├── classify.py                  ← Main classifier (bi-encoder + reranker)
 │   ├── eval_harness.py              ← Evaluation pipeline (P@k, R@k, MAP, CIs)
-│   ├── index_builder.py             ← FAISS index builder (1,514 controls)
+│   ├── index_builder.py             ← FAISS index builder (1,507 controls)
 │   ├── finetune.py                  ← Contrastive fine-tuning for BGE-small
 │   ├── reranker.py                  ← Cross-encoder reranker
 │   ├── contamination_probe.py       ← Generalization probe (CoSAI holdout)

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -43,7 +43,7 @@
   <!-- Crosswalk engine box -->
   <rect x='385' y='150' width='250' height='105' rx='10' fill='rgba(124,58,237,0.08)' stroke='rgba(124,58,237,0.25)' stroke-width='1'/>
   <text x='510' y='177' font-family='system-ui,sans-serif' font-size='11' fill='#a78bfa' text-anchor='middle' font-weight='700' letter-spacing='1.5'>CROSSWALK ENGINE</text>
-  <text x='510' y='200' font-family='monospace' font-size='12' fill='#cbd5e1' text-anchor='middle'>67 mapping files</text>
+  <text x='510' y='200' font-family='monospace' font-size='12' fill='#cbd5e1' text-anchor='middle'>70 mapping files</text>
   <text x='510' y='218' font-family='monospace' font-size='12' fill='#cbd5e1' text-anchor='middle'>BGE + cross-encoder classifier</text>
   <text x='510' y='236' font-family='monospace' font-size='12' fill='#cbd5e1' text-anchor='middle'>25 framework registries</text>
 
@@ -71,7 +71,7 @@
   <text x='132' y='330' font-family='system-ui,sans-serif' font-size='10' fill='#64748b' text-anchor='middle' letter-spacing='1'>FRAMEWORKS</text>
 
   <rect x='220' y='285' width='145' height='55' rx='8' fill='rgba(255,255,255,0.04)' stroke='rgba(255,255,255,0.08)' stroke-width='1'/>
-  <text x='292' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#a78bfa' text-anchor='middle'>1,514</text>
+  <text x='292' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#a78bfa' text-anchor='middle'>1,507</text>
   <text x='292' y='330' font-family='system-ui,sans-serif' font-size='10' fill='#64748b' text-anchor='middle' letter-spacing='1'>CONTROLS</text>
 
   <rect x='380' y='285' width='145' height='55' rx='8' fill='rgba(255,255,255,0.04)' stroke='rgba(255,255,255,0.08)' stroke-width='1'/>
@@ -79,15 +79,15 @@
   <text x='452' y='330' font-family='system-ui,sans-serif' font-size='10' fill='#64748b' text-anchor='middle' letter-spacing='1'>ENTRIES</text>
 
   <rect x='540' y='285' width='145' height='55' rx='8' fill='rgba(255,255,255,0.04)' stroke='rgba(255,255,255,0.08)' stroke-width='1'/>
-  <text x='612' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#fbbf24' text-anchor='middle'>3,210</text>
+  <text x='612' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#fbbf24' text-anchor='middle'>3,351</text>
   <text x='612' y='330' font-family='system-ui,sans-serif' font-size='10' fill='#64748b' text-anchor='middle' letter-spacing='1'>MAPPINGS</text>
 
   <rect x='700' y='285' width='145' height='55' rx='8' fill='rgba(255,255,255,0.04)' stroke='rgba(255,255,255,0.08)' stroke-width='1'/>
-  <text x='772' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#f87171' text-anchor='middle'>114</text>
+  <text x='772' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#f87171' text-anchor='middle'>125</text>
   <text x='772' y='330' font-family='system-ui,sans-serif' font-size='10' fill='#64748b' text-anchor='middle' letter-spacing='1'>INCIDENTS</text>
 
   <rect x='860' y='285' width='145' height='55' rx='8' fill='rgba(255,255,255,0.04)' stroke='rgba(255,255,255,0.08)' stroke-width='1'/>
-  <text x='932' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#38bdf8' text-anchor='middle'>67</text>
+  <text x='932' y='312' font-family='system-ui,sans-serif' font-size='24' font-weight='800' fill='#38bdf8' text-anchor='middle'>70</text>
   <text x='932' y='330' font-family='system-ui,sans-serif' font-size='10' fill='#64748b' text-anchor='middle' letter-spacing='1'>MAPPING FILES</text>
 
   <!-- Footer -->

--- a/docs/og-image.svg
+++ b/docs/og-image.svg
@@ -22,7 +22,7 @@
   <text x='145' y='377' font-family='system-ui,sans-serif' font-size='12' fill='#94a3b8' text-anchor='middle' letter-spacing='1'>FRAMEWORKS</text>
 
   <rect x='250' y='320' width='170' height='70' rx='10' fill='rgba(124,58,237,0.15)' stroke='rgba(124,58,237,0.3)' stroke-width='1'/>
-  <text x='335' y='352' font-family='system-ui,sans-serif' font-size='32' font-weight='800' fill='#a78bfa' text-anchor='middle'>1,514</text>
+  <text x='335' y='352' font-family='system-ui,sans-serif' font-size='32' font-weight='800' fill='#a78bfa' text-anchor='middle'>1,507</text>
   <text x='335' y='377' font-family='system-ui,sans-serif' font-size='12' fill='#94a3b8' text-anchor='middle' letter-spacing='1'>CONTROLS</text>
 
   <rect x='440' y='320' width='170' height='70' rx='10' fill='rgba(16,185,129,0.15)' stroke='rgba(16,185,129,0.3)' stroke-width='1'/>
@@ -30,11 +30,11 @@
   <text x='525' y='377' font-family='system-ui,sans-serif' font-size='12' fill='#94a3b8' text-anchor='middle' letter-spacing='1'>ENTRIES</text>
 
   <rect x='630' y='320' width='170' height='70' rx='10' fill='rgba(245,158,11,0.15)' stroke='rgba(245,158,11,0.3)' stroke-width='1'/>
-  <text x='715' y='352' font-family='system-ui,sans-serif' font-size='32' font-weight='800' fill='#fbbf24' text-anchor='middle'>67</text>
+  <text x='715' y='352' font-family='system-ui,sans-serif' font-size='32' font-weight='800' fill='#fbbf24' text-anchor='middle'>70</text>
   <text x='715' y='377' font-family='system-ui,sans-serif' font-size='12' fill='#94a3b8' text-anchor='middle' letter-spacing='1'>MAPPING FILES</text>
 
   <rect x='820' y='320' width='170' height='70' rx='10' fill='rgba(239,68,68,0.15)' stroke='rgba(239,68,68,0.3)' stroke-width='1'/>
-  <text x='905' y='352' font-family='system-ui,sans-serif' font-size='32' font-weight='800' fill='#f87171' text-anchor='middle'>114</text>
+  <text x='905' y='352' font-family='system-ui,sans-serif' font-size='32' font-weight='800' fill='#f87171' text-anchor='middle'>125</text>
   <text x='905' y='377' font-family='system-ui,sans-serif' font-size='12' fill='#94a3b8' text-anchor='middle' letter-spacing='1'>INCIDENTS</text>
 
   <!-- Architecture diagram - small -->


### PR DESCRIPTION
## What & why

The hero \docs/banner.svg\, social card \docs/og-image.svg\, README badge/text, and CITATION.cff still carried pre-#211 numbers. All figures re-derived from the data layer:

| Stat | Stale | Current | Where it was wrong |
|---|---|---|---|
| Controls | 1,514 | **1,507** | README badge + 5 text spots, CITATION.cff, both SVGs (ATLAS 50→43 in #211) |
| Incidents | 114 | **125** | both SVGs (incidents feed, #176) |
| Mapping files | 67 | **70** | banner engine box + stat card, og-image |
| Mappings | 3,210 | **3,351** | banner stat card |

Left as-is deliberately: \CHANGELOG.md\, \classifier/EVAL_REPORT.md\, and the web-app timeline entry — historical records of what was true at the time.

## Verification
- \
ode scripts/validate.js\ → PASSED
- \markdownlint README.md\ → clean
- Count-consistency CI checks the mapping-files badge (70, unchanged ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)