### PR TITLE
chore: EOL normalization (.gitattributes), noopener on external window.open, parser indent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings to LF for all text files. This overrides a contributor's
+# core.autocrlf=true (common on Windows), which otherwise reports every generated
+# file as modified (CRLF) and muddies diffs. Generated data/docs are written with LF.
+* text=auto eol=lf
+
+# Binary assets — never normalize.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary
+*.woff  binary
+*.woff2 binary

--- a/docs/index.html
+++ b/docs/index.html
@@ -1586,7 +1586,7 @@ input, select { font-family: inherit; }
     linkedInItem.appendChild(document.createTextNode('LinkedIn'));
     linkedInItem.addEventListener('click', function(e) {
       e.stopPropagation();
-      window.open('https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(url), '_blank', 'width=600,height=500');
+      window.open('https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(url), '_blank', 'width=600,height=500,noopener');
       menu.classList.remove('open');
     });
     menu.appendChild(linkedInItem);
@@ -1598,7 +1598,7 @@ input, select { font-family: inherit; }
     twitterItem.addEventListener('click', function(e) {
       e.stopPropagation();
       var text = title + ' — OWASP GenAI Security Crosswalk';
-      window.open('https://twitter.com/intent/tweet?url=' + encodeURIComponent(url) + '&text=' + encodeURIComponent(text), '_blank', 'width=600,height=400');
+      window.open('https://twitter.com/intent/tweet?url=' + encodeURIComponent(url) + '&text=' + encodeURIComponent(text), '_blank', 'width=600,height=400,noopener');
       menu.classList.remove('open');
     });
     menu.appendChild(twitterItem);
@@ -2948,9 +2948,9 @@ input, select { font-family: inherit; }
         inner.appendChild(linkBtn);
 
         card.appendChild(inner);
-        card.addEventListener('click', function() { window.open(tool.url, '_blank'); });
+        card.addEventListener('click', function() { window.open(tool.url, '_blank', 'noopener'); });
         card.addEventListener('keydown', function(e) {
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); window.open(tool.url, '_blank'); }
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); window.open(tool.url, '_blank', 'noopener'); }
         });
         grid.appendChild(card);
       });
@@ -3112,9 +3112,9 @@ input, select { font-family: inherit; }
 
         card.appendChild(inner);
         var url = baseUrl + '#' + recipeAnchor(recipe);
-        card.addEventListener('click', function() { window.open(url, '_blank'); });
+        card.addEventListener('click', function() { window.open(url, '_blank', 'noopener'); });
         card.addEventListener('keydown', function(e) {
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); window.open(url, '_blank'); }
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); window.open(url, '_blank', 'noopener'); }
         });
         grid.appendChild(card);
       });
@@ -5031,7 +5031,7 @@ input, select { font-family: inherit; }
         // LinkedIn share
         linkedInBtn.onclick = function() {
           var linkedInUrl = 'https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(shareUrl);
-          window.open(linkedInUrl, '_blank', 'width=600,height=600');
+          window.open(linkedInUrl, '_blank', 'width=600,height=600,noopener');
         };
 
         // Twitter/X share
@@ -5042,7 +5042,7 @@ input, select { font-family: inherit; }
             critCount + ' critical gaps identified. ' + highCount + ' high-severity gaps.\n\n' +
             'Free tool:\n\n#AISecurity #OWASP #GenAI #Cybersecurity';
           var twitterUrl = 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(tweetText) + '&url=' + encodeURIComponent(shareUrl);
-          window.open(twitterUrl, '_blank', 'width=600,height=400');
+          window.open(twitterUrl, '_blank', 'width=600,height=400,noopener');
         };
 
         // Get Badge
@@ -5441,7 +5441,7 @@ input, select { font-family: inherit; }
           if (navigator.clipboard) {
             navigator.clipboard.writeText(entry.badge);
           }
-          window.open(entry.badge, '_blank');
+          window.open(entry.badge, '_blank', 'noopener');
         });
       }
 
@@ -5743,7 +5743,7 @@ input, select { font-family: inherit; }
         '&publisher=' + encodeURIComponent(publisher) +
         '&framework-json=' + encodeURIComponent(jsonText);
 
-      window.open(issueUrl, '_blank');
+      window.open(issueUrl, '_blank', 'noopener');
     });
 
     // How it works section

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -391,32 +391,32 @@ function parseControlTable(sectionBody, frameworkName, qr, regIds) {
     }
 
     if (!controlId) {
-    if (id1.url) {
-      // col1 is a link — ID is the link text, name is col0 text
-      controlId   = id1.text;
-      controlName = id0.text;
-      controlUrl  = id1.url;
-    } else if (id0.url) {
-      // col0 is a link — name + url from col0, try col1 as ID
-      controlName = id0.text;
-      controlUrl  = id0.url;
-      controlId   = looksLikeId(id1.text) ? id1.text : id0.text;
-    } else if (looksLikeId(id1.text)) {
-      // col1 is a plain control ID
-      controlId   = id1.text;
-      controlName = id0.text;
-    } else {
-      // Try to extract CODE from col0 pattern "Name (CODE)"
-      const codeMatch = col0.match(/^(.*?)\s*\(([A-Z][A-Z0-9\-]{1,12})\)\s*$/);
-      if (codeMatch) {
-        controlName = codeMatch[1].trim();
-        controlId   = codeMatch[2];
-      } else {
-        // Fall back: use col1 as ID
-        controlId   = id1.text || id0.text;
+      if (id1.url) {
+        // col1 is a link — ID is the link text, name is col0 text
+        controlId   = id1.text;
         controlName = id0.text;
+        controlUrl  = id1.url;
+      } else if (id0.url) {
+        // col0 is a link — name + url from col0, try col1 as ID
+        controlName = id0.text;
+        controlUrl  = id0.url;
+        controlId   = looksLikeId(id1.text) ? id1.text : id0.text;
+      } else if (looksLikeId(id1.text)) {
+        // col1 is a plain control ID
+        controlId   = id1.text;
+        controlName = id0.text;
+      } else {
+        // Try to extract CODE from col0 pattern "Name (CODE)"
+        const codeMatch = col0.match(/^(.*?)\s*\(([A-Z][A-Z0-9\-]{1,12})\)\s*$/);
+        if (codeMatch) {
+          controlName = codeMatch[1].trim();
+          controlId   = codeMatch[2];
+        } else {
+          // Fall back: use col1 as ID
+          controlId   = id1.text || id0.text;
+          controlName = id0.text;
+        }
       }
-    }
     }
 
     // Skip separator / header rows that leaked through


### PR DESCRIPTION
Small polish batch — deferred items from the M2 review.

## Changes
- **.gitattributes** — force LF for text files via \* text=auto eol=lf\. A contributor's \core.autocrlf=true\ (Windows) was making git report every generated file as CRLF-modified, muddying diffs on every regen. **Verified no mass renormalization** (\git add --renormalize\ changed 0 files beyond the edits below — repo was already LF).
- **\docs/index.html\** — add \'noopener'\ to the 10 external-navigation \window.open(...)\ calls (deferred audit finding **L4**). The \bout:blank\ PDF-print window (line ~4504) deliberately keeps its reference (it needs \document.write\; same-origin, no reverse-tabnabbing risk).
- **\scripts/generate.js\** — re-indent the \if (!controlId) {\ wrap body from the M2 parser change (final-review cosmetic nit). **Generated output byte-identical** (confirmed idempotent).

## Verification
- \
ode scripts/validate.js\ → 0 errors / 386 passed
- \
ode scripts/audit-control-join.mjs\ → TOTAL join-misses: 0
- \
ode scripts/generate.js\ idempotent (indent change produces no output diff)
- noopener coverage: 10/11 \window.open\ (the print window correctly excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)